### PR TITLE
Working with all 3 versions of Caffe

### DIFF
--- a/docs/SSD-install.md
+++ b/docs/SSD-install.md
@@ -68,6 +68,41 @@ undefined reference to `SSL_CTX_new@OPENSSL_1.0.0'
 Make sure Caffe is not compiling against the Anaconda (or Miniconda) Python (unles you are using a virtualenv)
 
 
+#### Installing other versions of Caffe
+
+#### Caffe-jacinto
+If you are using `cmake` and you face compilation errors due to OpenCV missing libraries at linking phase, such as:
+
+```
+[ 89%] Linking CXX executable upgrade_net_proto_text
+[ 90%] Linking CXX executable upgrade_solver_proto_text
+[ 92%] Linking CXX executable net_speed_benchmark
+[ 92%] Built target test_net
+[ 92%] Built target net_speed_benchmark
+../lib/libcaffe-nv.so.0.16.4: undefined reference to `cv::VideoCapture::set(int, double)'
+../lib/libcaffe-nv.so.0.16.4: undefined reference to `cv::VideoWriter::write(cv::Mat const&)'
+../lib/libcaffe-nv.so.0.16.4: undefined reference to `cv::VideoCapture::open(cv::String const&)'
+../lib/libcaffe-nv.so.0.16.4: undefined reference to `cv::VideoCapture::release()'
+../lib/libcaffe-nv.so.0.16.4: undefined reference to `cv::VideoCapture::operator>>(cv::Mat&)'
+../lib/libcaffe-nv.so.0.16.4: undefined reference to `cv::VideoWriter::VideoWriter(cv::String const&, int, double, cv::Size_<int>, bool)'
+../lib/libcaffe-nv.so.0.16.4: undefined reference to `cv::VideoCapture::isOpened() const'
+../lib/libcaffe-nv.so.0.16.4: undefined reference to `cv::VideoCapture::get(int) const'
+../lib/libcaffe-nv.so.0.16.4: undefined reference to `cv::VideoWriter::VideoWriter()'
+../lib/libcaffe-nv.so.0.16.4: undefined reference to `cv::VideoCapture::open(int)'
+../lib/libcaffe-nv.so.0.16.4: undefined reference to `cv::VideoWriter::isOpened() const'
+../lib/libcaffe-nv.so.0.16.4: undefined reference to `cv::VideoWriter::~VideoWriter()'
+../lib/libcaffe-nv.so.0.16.4: undefined reference to `cv::VideoCapture::~VideoCapture()'
+../lib/libcaffe-nv.so.0.16.4: undefined reference to `cv::waitKey(int)'
+../lib/libcaffe-nv.so.0.16.4: undefined reference to `cv::imshow(cv::String const&, cv::_InputArray const&)'
+../lib/libcaffe-nv.so.0.16.4: undefined reference to `cv::VideoCapture::VideoCapture()'
+```
+
+Make sure you add the packages `imgproc videoio highgui` to the lines 74 and 77 of `$CAFFE_ROOT/cmake/Dependencies.cmake`:
+```
+find_package(OpenCV REQUIRED COMPONENTS core imgcodecs imgproc videoio highgui)
+```
+
+
 ##### GCC issues
 Make sure you have gcc<=6 in your system. You can install it with:
 

--- a/sfd_test_code/sfd_detector.py
+++ b/sfd_test_code/sfd_detector.py
@@ -4,9 +4,9 @@ import cv2
 import numpy as np
 
 import sys
-#sys.path.insert(0, '../../../caffe-jacinto/python')
+sys.path.insert(0, '../../../caffe-jacinto/python')
 #sys.path.insert(0, '../../../caffe-0.17/python')
-sys.path.insert(0, '../../python')
+#sys.path.insert(0, '../../python')
 import caffe
 
 

--- a/sfd_test_code/sfd_detector.py
+++ b/sfd_test_code/sfd_detector.py
@@ -4,6 +4,8 @@ import cv2
 import numpy as np
 
 import sys
+#sys.path.insert(0, '../../../caffe-jacinto/python')
+#sys.path.insert(0, '../../../caffe-0.17/python')
 sys.path.insert(0, '../../python')
 import caffe
 
@@ -41,7 +43,7 @@ class SFD_NET(caffe.Net):
         if pretrained_file is None:
             pretrained_file = MODEL_WEIGHTS
 
-        caffe.Net.__init__(self, model_file, caffe.TEST, weights=pretrained_file)
+        caffe.Net.__init__(self, model_file, pretrained_file, caffe.TEST)
 
     def get_transformer(self, shape):
         in_ = self.inputs[0]

--- a/sfd_test_code/test.py
+++ b/sfd_test_code/test.py
@@ -1,10 +1,7 @@
 from sfd_detector import SFD_NET
 import argparse
-import cv2
 import os.path
 import progressbar
-import sys
-sys.path.insert(0, '../../python')
 import caffe
 
 
@@ -22,7 +19,6 @@ def process_imgs_list(imgs_list_file, output_file, dataset_path, origin, device=
             shrink = 1
             if origin in ['AFW', 'PASCAL']:
                 shrink = 640.0 / max(image.shape[0], image.shape[1])
-                #image = cv2.resize(image, None, None, fx=ratio, fy=ratio, interpolation=cv2.INTER_LINEAR)
         
             detections = net.detect(image, shrink=shrink)
 


### PR DESCRIPTION
Small changes in the Net initialization so it can work with Nvidia Caffe 0.17, caffe-jacinto and SSD Caffe.
Results for caffe-jacinto are good:

## Accuracies
Caffe SSD commit: 4817bf8b
Caffe Nvidia 0.17 commit: 9c674a8e. With fix # 493, using float32
Caffe jacinto commit: de52e822 

 version     |   AFW | FDDB | PASCAL 
-------------|-------|------|--------
 SSD         | 99.85 | 98.2 |  98.49 
 NVIDIA 0.17 | 94.01 | 91.3 |  78.25 
JACINTO     | 99.85 | 98.2 |  98.49 

## Execution times in seconds (avg over 3 runs):
AFW: 205 images
FDDB: 2845 images
PASCAL: 851 images

version     |   AFW |   FDDB | PASCAL | avg forward time 
-------------|----------|----------|-------------|----
 SSD         | 21.56 |  69.76 |  35.49 |         0.17 
 NVIDIA 0.17 | 26.66 | 111.04 |  53.64 |         0.23 
jacinto | 23.58 |  84.11 |  42.86 |         0.19

